### PR TITLE
DM-38951: Add MemoryTester to meas_transiNet::test_ModelPackage

### DIFF
--- a/tests/test_ModelPackage.py
+++ b/tests/test_ModelPackage.py
@@ -234,3 +234,16 @@ class TestModelPackageNeighbor(unittest.TestCase):
         # of input channels.
         self.assertEqual(len(model_package.get_input_scale_factors()),
                          model_package.get_model_input_shape()[2])
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
Made the following modifications to the code:
- Define the ```MemoryTester``` class
- Define the ```setup_module``` method
- Add the ```main``` block