### PR TITLE
DM-41213: Clarify error message for missing rbClassifier_data

### DIFF
--- a/python/lsst/meas/transiNet/modelPackages/storageAdapterNeighbor.py
+++ b/python/lsst/meas/transiNet/modelPackages/storageAdapterNeighbor.py
@@ -35,7 +35,10 @@ class StorageAdapterNeighbor(StorageAdapterBase):
         try:
             base_path = os.environ['RBCLASSIFIER_DATA_DIR']
         except KeyError:
-            raise RuntimeError("The environment variable RBCLASSIFIER_DATA_DIR is not set.")
+            raise RuntimeError("Cannot find the lsst-dm/rbClassifier_data package; "
+                               "is it downloaded and set up?\n"
+                               "See https://pipelines.lsst.io/v/daily/modules/lsst.ap.verify/running.html "
+                               "for details on setting up packages from GitHub.")
 
         return os.path.join(base_path, 'model_packages')
 


### PR DESCRIPTION
This PR tries to make the error message produced when `rbClassifier_data` is not loaded more user-friendly. Hopefully this will reduce the frequency of questions about it on Slack.