### PR TITLE
DM-42330: Add empty pytest configuration back

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,3 +8,5 @@ exclude =
 	**/*/__init__.py,
 	**/*/version.py,
 	tests/.tests
+
+[tool:pytest]


### PR DESCRIPTION
This empty config entry is important since it stops pytest from trying to find possibly incompatible configurations in parent directories.

This reverts commit 7bb791f4aa917628d9b06cb4cfcc143f12b78f68.